### PR TITLE
Add CreatedAt and UpdatedAt timestamps to users

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,8 @@ module api
 go 1.20
 
 require (
-	github.com/gorilla/mux v1.8.1 // indirect
-	github.com/lib/pq v1.10.9 // indirect
+	github.com/gorilla/mux v1.8.1
+	github.com/lib/pq v1.10.9
 )
+
+require github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,4 +1,7 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv" // Added for strconv.Itoa
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gorilla/mux"
+)
+
+// Helper function to create a mock DB and sqlmock instance
+func NewMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	return db, mock
+}
+
+func TestCreateUserHandler(t *testing.T) {
+	db, mock := NewMockDB(t)
+	defer db.Close()
+
+	handler := createUser(db) // Get the handler function
+
+	newUser := User{Name: "Test User", Email: "test@example.com"}
+	jsonBody, _ := json.Marshal(newUser)
+	req, err := http.NewRequest("POST", "/api/go/users", bytes.NewBuffer(jsonBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+
+	// Expectations for QueryRow:
+	// We expect an INSERT statement.
+	// The arguments are Name, Email, CreatedAt, UpdatedAt.
+	// We will check CreatedAt and UpdatedAt are recent.
+	// It should return the new user's ID.
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO users (name, email, created_at, updated_at) VALUES ($1, $2, $3, $4) RETURNING id`)).
+		WithArgs(newUser.Name, newUser.Email, sqlmock.AnyArg(), sqlmock.AnyArg()). // Using AnyArg for timestamps initially
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))                  // Mock returning ID 1
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+		t.Errorf("response body: %s", rr.Body.String())
+	}
+
+	var createdUser User
+	if err := json.NewDecoder(rr.Body).Decode(&createdUser); err != nil {
+		t.Fatalf("could not decode response: %v", err)
+	}
+
+	if createdUser.Id != 1 {
+		t.Errorf("expected user ID to be 1, got %d", createdUser.Id)
+	}
+	if createdUser.Name != newUser.Name {
+		t.Errorf("expected user name to be %s, got %s", newUser.Name, createdUser.Name)
+	}
+	if createdUser.Email != newUser.Email {
+		t.Errorf("expected user email to be %s, got %s", newUser.Email, createdUser.Email)
+	}
+
+	// Check timestamps - they should be recent (e.g., within a few seconds of now)
+	// This is more robust than sqlmock.AnyArg() for the assertion part.
+	now := time.Now()
+	if createdUser.CreatedAt.IsZero() || now.Sub(createdUser.CreatedAt) > 5*time.Second {
+		t.Errorf("expected CreatedAt to be recent, got %v", createdUser.CreatedAt)
+	}
+	if createdUser.UpdatedAt.IsZero() || now.Sub(createdUser.UpdatedAt) > 5*time.Second {
+		t.Errorf("expected UpdatedAt to be recent, got %v", createdUser.UpdatedAt)
+	}
+	// Check if CreatedAt and UpdatedAt are very close, e.g., within a millisecond
+	if createdUser.CreatedAt.Sub(createdUser.UpdatedAt).Abs() > time.Millisecond {
+		t.Errorf("expected CreatedAt and UpdatedAt to be very close for new user, got CreatedAt=%v, UpdatedAt=%v, diff=%v", createdUser.CreatedAt, createdUser.UpdatedAt, createdUser.CreatedAt.Sub(createdUser.UpdatedAt).Abs())
+	}
+
+
+	// we make sure that all expectations were met
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func TestUpdateUserHandler(t *testing.T) {
+	db, mock := NewMockDB(t)
+	defer db.Close()
+
+	handler := updateUser(db) // Get the handler function
+
+	originalCreatedAt := time.Now().Add(-1 * time.Hour) // An hour ago
+	userID := 1
+	updateInfo := User{Name: "Updated User", Email: "updated@example.com"} // ID is not in body for PUT, it's in URL
+	userIDStr := strconv.Itoa(userID)
+
+	jsonBody, _ := json.Marshal(updateInfo)
+	// Need to use mux to extract path variables like {id}
+	req, err := http.NewRequest("PUT", "/api/go/users/"+userIDStr, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = mux.SetURLVars(req, map[string]string{"id": userIDStr})
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+
+	// Expectation for Exec (UPDATE statement)
+	// Args: name, email, updated_at, id
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE users SET name = $1, email = $2, updated_at = $3 WHERE id = $4`)).
+		WithArgs(updateInfo.Name, updateInfo.Email, sqlmock.AnyArg(), userIDStr). // Use userIDStr (string)
+		WillReturnResult(sqlmock.NewResult(1, 1))                                // 1 row affected
+
+	// Expectation for QueryRow (SELECT statement after update)
+	// Returns: id, name, email, created_at, updated_at
+	// We need to ensure created_at is the original one. Updated_at will be new.
+	// The ID passed to QueryRow in the actual code is also the string from mux.Vars.
+	rows := sqlmock.NewRows([]string{"id", "name", "email", "created_at", "updated_at"}).
+		AddRow(userID, updateInfo.Name, updateInfo.Email, originalCreatedAt, time.Now()) // Mock new updated_at. Note: AddRow provides int for userID, but Scan handles it.
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, name, email, created_at, updated_at FROM users WHERE id = $1`)).
+		WithArgs(userIDStr). // Use userIDStr (string) here as well.
+		WillReturnRows(rows)
+
+	handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+		t.Logf("Response body: %s", rr.Body.String())
+	}
+
+	var updatedUser User
+	if err := json.NewDecoder(rr.Body).Decode(&updatedUser); err != nil {
+		// If there's an error decoding, print the body for debugging
+		if strings.Contains(err.Error(), "EOF") && rr.Body.Len() == 0 {
+			t.Fatalf("could not decode response: empty body")
+		} else {
+			t.Fatalf("could not decode response: %v. Body: %s", err, rr.Body.String())
+		}
+	}
+
+
+	if updatedUser.Id != userID {
+		t.Errorf("expected user ID to be %d, got %d", userID, updatedUser.Id)
+	}
+	if updatedUser.Name != updateInfo.Name {
+		t.Errorf("expected user name to be %s, got %s", updateInfo.Name, updatedUser.Name)
+	}
+	if updatedUser.Email != updateInfo.Email {
+		t.Errorf("expected user email to be %s, got %s", updateInfo.Email, updatedUser.Email)
+	}
+
+	// Check timestamps
+	if !updatedUser.CreatedAt.Equal(originalCreatedAt) {
+		t.Errorf("expected CreatedAt to be unchanged (%v), got %v", originalCreatedAt, updatedUser.CreatedAt)
+	}
+
+	now := time.Now()
+	if updatedUser.UpdatedAt.IsZero() || now.Sub(updatedUser.UpdatedAt) > 5*time.Second {
+		t.Errorf("expected UpdatedAt to be recent, got %v", updatedUser.UpdatedAt)
+	}
+	if updatedUser.CreatedAt.After(updatedUser.UpdatedAt) {
+		t.Errorf("expected CreatedAt (%v) to be before or equal to UpdatedAt (%v)", updatedUser.CreatedAt, updatedUser.UpdatedAt)
+	}
+
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}

--- a/frontend/src/components/CardComponent.tsx
+++ b/frontend/src/components/CardComponent.tsx
@@ -4,14 +4,36 @@ interface Card {
   id: number;
   name: string;
   email: string;
+  created_at: string;
+  updated_at: string;
 }
 
 const CardComponent: React.FC<{ card: Card }> = ({ card }) => {
+  const formatDate = (dateString: string) => {
+    if (!dateString) return 'N/A';
+    try {
+      const options: Intl.DateTimeFormatOptions = {
+        year: 'numeric', month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit', hour12: true
+      };
+      return new Date(dateString).toLocaleString(undefined, options);
+    } catch (e) {
+      console.error("Error formatting date:", e);
+      return dateString; // return original if formatting fails
+    }
+  };
+
   return (
-    <div className="bg-white shadow-lg rounded-lg p-2 mb-2 hover:bg-gray-100">
+    <div className="bg-white shadow-lg rounded-lg p-2 mb-2 hover:bg-gray-100 w-full">
       <div className="text-sm text-gray-600">Id: {card.id}</div>
       <div className="text-lg font-semibold text-gray-800">{card.name}</div>
       <div className="text-md text-gray-700">{card.email}</div>
+      <div className="text-xs text-gray-500 mt-1">
+        Created: {formatDate(card.created_at)}
+      </div>
+      <div className="text-xs text-gray-500">
+        Updated: {formatDate(card.updated_at)}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/UserInterface.tsx
+++ b/frontend/src/components/UserInterface.tsx
@@ -6,6 +6,8 @@ interface User {
   id: number;
   name: string;
   email: string;
+  created_at: string; 
+  updated_at: string; 
 }
 
 interface UserInterfaceProps {
@@ -15,8 +17,8 @@ interface UserInterfaceProps {
 const UserInterface: React.FC<UserInterfaceProps> = ({ backendName }) => {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
   const [users, setUsers] = useState<User[]>([]);
-  const [newUser, setNewUser] = useState({ name: '', email: '' });
-  const [updateUser, setUpdateUser] = useState({ id: '', name: '', email: '' });
+  const [newUser, setNewUser] = useState({ name: '', email: ''});
+  const [updateUser, setUpdateUser] = useState({ id: '', name: '', email: ''});
 
   // Define styles based on the backend name
   const backgroundColors: { [key: string]: string } = {
@@ -49,7 +51,8 @@ const UserInterface: React.FC<UserInterfaceProps> = ({ backendName }) => {
     e.preventDefault();
 
     try {
-      const response = await axios.post(`${apiUrl}/api/${backendName}/users`, newUser);
+      // Assume newUser only contains name and email, backend will add timestamps
+      const response = await axios.post(`${apiUrl}/api/${backendName}/users`, {name: newUser.name, email: newUser.email});
       setUsers([response.data, ...users]);
       setNewUser({ name: '', email: '' });
     } catch (error) {
@@ -61,12 +64,15 @@ const UserInterface: React.FC<UserInterfaceProps> = ({ backendName }) => {
   const handleUpdateUser = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     try {
-      await axios.put(`${apiUrl}/api/${backendName}/users/${updateUser.id}`, { name: updateUser.name, email: updateUser.email });
+      // Send only name and email for update, backend handles updated_at
+      const response = await axios.put(`${apiUrl}/api/${backendName}/users/${updateUser.id}`, { name: updateUser.name, email: updateUser.email });
+      const updatedUserFromServer = response.data;
       setUpdateUser({ id: '', name: '', email: '' });
       setUsers(
         users.map((user) => {
           if (user.id === parseInt(updateUser.id)) {
-            return { ...user, name: updateUser.name, email: updateUser.email };
+            // Update user with new name, email, and updated_at from server, keep original created_at
+            return { ...user, name: updatedUserFromServer.name, email: updatedUserFromServer.email, updated_at: updatedUserFromServer.updated_at };
           }
           return user;
         })


### PR DESCRIPTION
This commit introduces timestamping functionality for user records.

Backend:
- The `User` struct in `backend/main.go` now includes `CreatedAt` and `UpdatedAt` fields.
- The database schema for the `users` table has been updated to include `created_at` and `updated_at` columns.
- The `createUser` handler now sets both `CreatedAt` and `UpdatedAt` to the current time upon user creation.
- The `updateUser` handler now updates the `UpdatedAt` field to the current time upon user modification.
- Unit tests have been added to verify the correct behavior of timestamp setting and updating in the backend.

Frontend:
- The `User` interface in `frontend/src/components/UserInterface.tsx` has been updated to include `created_at` and `updated_at`.
- The `CardComponent.tsx` now displays the `CreatedAt` and `UpdatedAt` timestamps for each user in a human-readable format.